### PR TITLE
Fix resolve problem details with string message

### DIFF
--- a/problem_details.go
+++ b/problem_details.go
@@ -141,10 +141,10 @@ func ResolveProblemDetails(w http.ResponseWriter, r *http.Request, err error) (P
 		err = errors.New(fiberError.Message)
 	} else if errors.As(err, &echoError) {
 		statusCode = err.(*echo.HTTPError).Code
-		if errors.As(err.(*echo.HTTPError).Message, &err) {
-			err = err.(*echo.HTTPError).Message.(error)
-		} else {
-			err = errors.New(err.(*echo.HTTPError).Message.(string))
+		if messageErr, ok := err.(*echo.HTTPError).Message.(error); ok {
+			err = messageErr
+		} else if messageStr, ok := err.(*echo.HTTPError).Message.(string); ok {
+			err = errors.New(messageStr)
 		}
 	} else if errors.As(err, &ginError) {
 		var rw, ok = w.(gin.ResponseWriter)

--- a/problem_details.go
+++ b/problem_details.go
@@ -131,7 +131,6 @@ func Map[T error](funcProblem func() ProblemDetailErr) {
 
 // ResolveProblemDetails retrieve and resolve error with format problem details error
 func ResolveProblemDetails(w http.ResponseWriter, r *http.Request, err error) (ProblemDetailErr, error) {
-
 	var statusCode int = http.StatusInternalServerError
 	var echoError *echo.HTTPError
 	var ginError *gin.Error
@@ -142,7 +141,11 @@ func ResolveProblemDetails(w http.ResponseWriter, r *http.Request, err error) (P
 		err = errors.New(fiberError.Message)
 	} else if errors.As(err, &echoError) {
 		statusCode = err.(*echo.HTTPError).Code
-		err = err.(*echo.HTTPError).Message.(error)
+		if errors.As(err.(*echo.HTTPError).Message, &err) {
+			err = err.(*echo.HTTPError).Message.(error)
+		} else {
+			err = errors.New(err.(*echo.HTTPError).Message.(string))
+		}
 	} else if errors.As(err, &ginError) {
 		var rw, ok = w.(gin.ResponseWriter)
 		if ok && rw.Written() {

--- a/problem_details_test.go
+++ b/problem_details_test.go
@@ -92,7 +92,33 @@ func TestMap_Status_Echo(t *testing.T) {
 	p, _ := ResolveProblemDetails(c.Response(), c.Request(), err)
 
 	assert.Equal(t, c.Response().Status, http.StatusUnauthorized)
-	assert.Equal(t, err.(*echo.HTTPError).Message.(error).Error(), p.GetDetails())
+	assert.Equal(t, "We have a specific status code error in our endpoint", p.GetDetails())
+	assert.Equal(t, "unauthorized", p.GetTitle())
+	assert.Equal(t, "https://httpstatuses.io/401", p.GetType())
+	assert.Equal(t, http.StatusUnauthorized, p.GetStatus())
+}
+
+func TestMap_Status2_Echo(t *testing.T) {
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "http://echo_endpoint2", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := echo_endpoint2b(c)
+
+	MapStatus(http.StatusBadGateway, func() ProblemDetailErr {
+		return &ProblemDetail{
+			Status: http.StatusUnauthorized,
+			Title:  "unauthorized",
+			Detail: err.Error(),
+		}
+	})
+
+	p, _ := ResolveProblemDetails(c.Response(), c.Request(), err)
+
+	assert.Equal(t, c.Response().Status, http.StatusUnauthorized)
+	assert.Equal(t, "We have a specific status code error in our endpoint", p.GetDetails())
 	assert.Equal(t, "unauthorized", p.GetTitle())
 	assert.Equal(t, "https://httpstatuses.io/401", p.GetType())
 	assert.Equal(t, http.StatusUnauthorized, p.GetStatus())
@@ -395,6 +421,10 @@ func echo_endpoint1(c echo.Context) error {
 func echo_endpoint2(c echo.Context) error {
 	err := errors.New("We have a specific status code error in our endpoint")
 	return echo.NewHTTPError(http.StatusBadGateway, err)
+}
+
+func echo_endpoint2b(c echo.Context) error {
+	return echo.NewHTTPError(http.StatusBadGateway, "We have a specific status code error in our endpoint")
 }
 
 func echo_endpoint3(c echo.Context) error {


### PR DESCRIPTION
Fix "interface conversion: string is not error: missing method Error" in cases like echo.NewHTTPError(http.StatusUnauthorized), where there is not an error in the interface field "message"